### PR TITLE
Specify setuptools patch version to avoid setuptools error 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     packages = find_packages(exclude=('docs')),
     setup_requires=[
         'twine>=1.11.0',
-        'setuptools>=38.6.'] + ([] if sys.version_info.minor == 4 else ['wheel>=0.31.0']),
+        'setuptools>=38.6.0',
+    ] + ([] if sys.version_info.minor == 4 else ['wheel>=0.31.0']),
     include_package_data = True
 )

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
     packages = find_packages(exclude=('docs')),
     setup_requires=[
         'twine>=1.11.0',
-        'setuptools>=38.6.',
-    ] + ([] if sys.version_info.minor == 4 else ['wheel>=0.31.0']),
+        'setuptools>=38.6.'] + ([] if sys.version_info.minor == 4 else ['wheel>=0.31.0']),
     include_package_data = True
 )


### PR DESCRIPTION
**What was changed** 
If you try to install attachi with newer python versions it fails due to the following error: 

```
  error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [3 lines of output]
      error in attachi setup command: 'setup_requires' must be a string or list of strings containing valid project/version requirement specifiers; Expected end or semicolon (after version specifier)
          setuptools>=38.6.
                    ~~~~~~^
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed
```

This can be circumvented by specifying the patch version of the to be used setuptools version. 
In theory the whole setup.py needs to be updated since it's[ deprecated ](https://peps.python.org/pep-0518/), however this is not feasible 

**How to test** 
How to reproduce error (python 3.7) :
  
pip install git+https://github.com/qbicsoftware/attachi-cli

How to test if fix works: 

python -m pip install git+https://github.com/qbicsoftware/attachi-cli@fix/setup-requires-deprecation --dry-run

